### PR TITLE
fix(event): update event scale labels and adjust disabled options in editor

### DIFF
--- a/src/consts/event.ts
+++ b/src/consts/event.ts
@@ -14,12 +14,12 @@ export const EventStatusLabel = {
 };
 
 export const EventScaleLabel = {
-  [EventScale.Cosy]: "迷你(50+)",
+  [EventScale.Cosy]: "迷你(0-100)",
   [EventScale.Small]: "小型(100+)",
   [EventScale.Medium]: "中型(500+)",
   [EventScale.Large]: "大型(1000+)",
   [EventScale.XLarge]: "特大型(3000+)",
-  [EventScale.XXLarge]: "超特大型(6000+)",
+  [EventScale.XXLarge]: "超特大型(5000+)",
   [EventScale.Mega]: "巨型(10000+)",
 };
 

--- a/src/pages/dashboard/event/edit/index.tsx
+++ b/src/pages/dashboard/event/edit/index.tsx
@@ -405,6 +405,7 @@ function EventEditorContent({ event }: { event?: EventItem }) {
               data={Object.keys(EventScale).map((key) => ({
                 label: EventScaleLabel[EventScale[key as EventScaleKeyType]],
                 value: EventScale[key as EventScaleKeyType],
+                disabled: ["Mega", "XXLarge"].includes(key),
               }))}
               {...form.getInputProps("scale")}
             />

--- a/src/pages/dashboard/organization/edit/index.tsx
+++ b/src/pages/dashboard/organization/edit/index.tsx
@@ -129,7 +129,7 @@ function OrganizationEditorContent({
       ...validFormData,
       creationTime: formData.creationTime
         ? formData.creationTime.toISOString()
-        : null,
+        : undefined,
     });
     const validPayload = validResult.data;
 

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -33,9 +33,9 @@ export const EventScale = {
   Small: "small",
   /** 一线城市的展会但是不是很有名一般用这个，比如：上海兽界 */
   Medium: "medium",
-  /** 以极兽聚为代表的超过1000人以上的展会 */
+  /** 大型展会 */
   Large: "large",
-  /** 特大型展会 */
+  /** 特大型展会,以极兽聚为代表的超过3000人以上的展会 */
   XLarge: "xlarge",
   /**超特大型展会 */
   XXLarge: "xxlarge",


### PR DESCRIPTION
This pull request includes updates to event scaling labels, adjustments to form behaviors, and clarifications in comments. The most important changes involve modifying event scale labels and descriptions, disabling certain scale options in the event editor, and refining form handling for organization creation times.

### Updates to event scaling:

* [`src/consts/event.ts`](diffhunk://#diff-79c2cc879deb40618a7c78138897b1262a603bfb2a75ce895ef850874bf216c0L17-R22): Updated the `EventScaleLabel` to revise the ranges for "迷你" (from "50+" to "0-100") and "超特大型" (from "6000+" to "5000+").
* [`src/types/event.ts`](diffhunk://#diff-0aac24f975fc3784a9cf6ab719f60ba05cdb8da04b93ac9a406f739c7ae61330L36-R38): Updated comments in `EventScale` to clarify the definitions of "大型" and "特大型" events, including references to specific examples and adjusted thresholds.

### Adjustments to form behaviors:

* [`src/pages/dashboard/event/edit/index.tsx`](diffhunk://#diff-748542231a95b7542fa282787cc6cdbfb350081f964d2327c87b2276fb611632R408): Disabled the "Mega" and "XXLarge" event scale options in the event editor dropdown.
* [`src/pages/dashboard/organization/edit/index.tsx`](diffhunk://#diff-f08c8f66679888dbc2e5a6100e5d7a2a91afac49a7b76c0c84149f5a1ed3a611L132-R132): Changed the fallback value for `creationTime` in the organization editor from `null` to `undefined` to better align with expected data handling.